### PR TITLE
Bug fix: Allow "host_without_subdomain" to handle 2 level domain resolution to 1 domain

### DIFF
--- a/lib/subdomain-fu.rb
+++ b/lib/subdomain-fu.rb
@@ -83,7 +83,7 @@ module SubdomainFu
 
   def self.host_without_subdomain(host)
     parts = host.split('.')
-    parts[-(SubdomainFu.config.tld_size+1)..-1].join(".")
+    parts[-(SubdomainFu.config.tld_size+1)..-1] ? parts[-(SubdomainFu.config.tld_size+1)..-1].join(".") : parts
   end
 
   # Rewrites the subdomain of the host unless they are equivalent (i.e. mirrors of each other)


### PR DESCRIPTION
When a local /etc/hosts file is used to resolve a domain name with more than 1 level to a domain with 1 level, (for example: "x.dev" -> "localhost"), the logic in SubdomainFu.host_without_subdomain fails since it is using the one-level domain to split on the "." character. The tld_size is 1 for the "x.dev" domain to be processed correctly URL wise, but because at this level,  the host is reported as "localhost" the tld_size is effectively changed.

This mod. simply checks to make sure that "parts[-(SubdomainFu.config.tld_size+1)..-1]" is non-nil before attempting to call "join" on it.
